### PR TITLE
feat: use -Data instead of .@ for content

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The tool reads YAML form `stdin`, and writes XML to `stdout`. Below are a few ex
     yaml2xml << EOF
     Parent:
       - Child: Fizz
-      - Child: Buzz' | yaml2xml
+      - Child: Buzz
     EOF
     ```
   * Reading input piped from another process
@@ -407,7 +407,6 @@ loop constructs, conditional elements, template blocks for re-use and much more.
 * **Control the Output:** Use control logic in your template to adjust your proxy configuration based on your OpenAPI spec.
 * **Access the Spec:** The OpenAPI text and [map](https://go.dev/blog/maps) are available during template rendering.
 
-Once you render the template, you then use the `yaml2bundle` tool to transform this YAML output into a deployable API Proxy bundle.
 
 **See an Example:** Check out the included OAS3 template at [examples/template/oas3](examples/templates/oas3/apiproxy.yaml). 
 
@@ -425,7 +424,12 @@ render-oas -template ./examples/templates/oas3/apiproxy.yaml \
 > [!NOTE]
 > You may pass the `-include` flag multiple time to load template helpers from multiple sources.
 
+Once you render the template, you then use the `yaml2bundle` tool to transform this YAML output into a deployable API Proxy bundle. e.g.
 
+```shell
+yaml2bundle -input ./out/yaml-first/petstore/apiproxy.yaml \
+            -output ./out/bundles/petstore-from-oas.zip
+```
 
 **Quick Template Previews with Dry Run**
 
@@ -465,6 +469,13 @@ render-graphql -template ./examples/templates/graphql/apiproxy.yaml \
                -include ./examples/templates/graphql/*.tmpl \
                -output ./out/yaml-first/resorts/apiproxy.yaml
 ``` 
+Once you render the template, you then use the `yaml2bundle` tool to transform this YAML output into a deployable API Proxy bundle. e.g.
+
+```shell
+yaml2bundle -input ./out/yaml-first/resorts/apiproxy.yaml \
+            -output ./out/bundles/resorts-from-graphql.zip
+``` 
+
 
 ### Tool: render-grpc
 
@@ -496,6 +507,13 @@ render-grpc -template ./examples/templates/grpc/apiproxy.yaml \
             -set-string "target_server=example-target-server" \
             -include ./examples/templates/grpc/*.tmpl \
             -output ./out/yaml-first/greeter/apiproxy.yaml
+```
+
+Once you render the template, you then use the `yaml2bundle` tool to transform this YAML output into a deployable API Proxy bundle. e.g.
+
+```shell
+yaml2bundle -input ./out/yaml-first/greeter/apiproxy.yaml \
+            -output ./out/bundles/greeter-from-grpc.zip
 ```
 
 ### Tool: render-template

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -66,7 +66,7 @@ RaiseFault:
         Headers:
           - Header:
               .name: user-agent
-              .@: example
+              -Data: example
     - Copy:
         .source: request
         Headers:
@@ -81,10 +81,10 @@ RaiseFault:
         Headers:
           - Header:
               .name: user-agent
-              .@: "{request.header.user-agent}"
+              -Data: "{request.header.user-agent}"
         Payload:
           .contentType: application/json
-          .@: '{"name":"foo", "type":"bar"}'
+          -Data: '{"name":"foo", "type":"bar"}'
     - Set:
         ReasonPhrase: Server Error
         StatusCode: 500

--- a/examples/snippets/raise-fault.yaml
+++ b/examples/snippets/raise-fault.yaml
@@ -12,7 +12,7 @@ RaiseFault:
         Headers:
           Header:
             .name: user-agent
-            .@: example
+            -Data: example
     - Copy:
         .source: request
         Headers:
@@ -27,10 +27,10 @@ RaiseFault:
         Headers:
           Header:
             .name: user-agent
-            .@: '{request.header.user-agent}'
+            -Data: '{request.header.user-agent}'
         Payload:
           .contentType: application/json
-          .@: '{"name":"foo", "type":"bar"}'
+          -Data: '{"name":"foo", "type":"bar"}'
     - Set:
         ReasonPhrase: Server Error
         StatusCode: 500

--- a/examples/templates/graphql/apiproxy.yaml
+++ b/examples/templates/graphql/apiproxy.yaml
@@ -1,9 +1,8 @@
 APIProxy:
   .revision: 1
   .name: {{ $.Values.api_name }}
-  .@:
-    DisplayName: {{ $.Values.api_name }}
-    Description: {{ $.Schema.Description }}
+  DisplayName: {{ $.Values.api_name }}
+  Description: {{ $.Schema.Description }}
 Policies:
   #{{- os_copyfile "./policies.yaml" "./policies.yaml" | blank }}
   $ref: ./policies.yaml#/

--- a/examples/templates/graphql/policies.yaml
+++ b/examples/templates/graphql/policies.yaml
@@ -15,7 +15,7 @@
       Set:
         Payload:
           .contentType: application/json
-          .@: |-
+          -Data: |-
             {
                "status": 404
                "error": "NotFound"

--- a/examples/templates/grpc/policies.yaml
+++ b/examples/templates/grpc/policies.yaml
@@ -7,7 +7,7 @@
       Set:
         Payload:
           .contentType: application/json
-          .@: |-
+          -Data: |-
             {
                "status": 404
                "error": "NotFound"

--- a/examples/templates/oas3/policies.yaml
+++ b/examples/templates/oas3/policies.yaml
@@ -14,7 +14,7 @@
       Set:
         Payload:
           .contentType: application/json
-          .@: |-
+          -Data: |-
             {
                "status": 404
                "error": "NotFound"

--- a/examples/yaml-first/petstore/policies.yaml
+++ b/examples/yaml-first/petstore/policies.yaml
@@ -14,7 +14,7 @@
       Set:
         Payload:
           .contentType: application/json
-          .@: |-
+          -Data: |-
             {
                "status": 404
                "error": "NotFound"

--- a/pkg/utils/testdata/snippets/complex_raise_fault_policy/data.yaml
+++ b/pkg/utils/testdata/snippets/complex_raise_fault_policy/data.yaml
@@ -12,7 +12,7 @@ RaiseFault:
         Headers:
           Header:
             .name: user-agent
-            .@: example
+            -Data: example
     - Copy:
         .source: request
         Headers:
@@ -27,10 +27,10 @@ RaiseFault:
         Headers:
           Header:
             .name: user-agent
-            .@: '{request.header.user-agent}'
+            -Data: '{request.header.user-agent}'
         Payload:
           .contentType: application/json
-          .@: '{"name":"foo", "type":"bar"}'
+          -Data: '{"name":"foo", "type":"bar"}'
     - Set:
         ReasonPhrase: Server Error
         StatusCode: 500

--- a/pkg/utils/testdata/snippets/scalar_with_attrs/data.yaml
+++ b/pkg/utils/testdata/snippets/scalar_with_attrs/data.yaml
@@ -1,3 +1,3 @@
 Parent:
   .foo: bar
-  .@: Content
+  -Data: Content

--- a/pkg/utils/testdata/snippets/sequence_parent_with_attrs/data.yaml
+++ b/pkg/utils/testdata/snippets/sequence_parent_with_attrs/data.yaml
@@ -1,6 +1,6 @@
 Parent:
   .attr1: value1
   .attr2: value2
-  .@:
+  -Data:
     - Child: foo
     - Child: bar

--- a/pkg/utils/testdata/snippets/sequence_without_parent_with_attrs/data.yaml
+++ b/pkg/utils/testdata/snippets/sequence_without_parent_with_attrs/data.yaml
@@ -1,7 +1,7 @@
 Root:
   .attr1: val1
   .attr2: val2
-  .@:
+  -Data:
     - Child:
         .name: foo
     - Child:

--- a/pkg/utils/testdata/snippets/unique_children_with_attrs_parent_without_attrs/data.yaml
+++ b/pkg/utils/testdata/snippets/unique_children_with_attrs_parent_without_attrs/data.yaml
@@ -1,7 +1,7 @@
 Root:
   Child1:
     .name: foo
-    .@: foo
+    -Data: foo
   Child2:
     .name: bar
-    .@: bar
+    -Data: bar

--- a/pkg/utils/xml.go
+++ b/pkg/utils/xml.go
@@ -174,10 +174,11 @@ func XML2YAMLRecursive(ele *etree.Element) (key *yaml.Node, value *yaml.Node, er
 
 	var children *yaml.Node
 	charEle, _ := getCharElement(ele)
+	const cData = "-Data"
 	if charEle != nil && len(ele.Attr) > 0 {
 		if len(charEle.Data) > 0 {
 			nodeVal.Content = append(nodeVal.Content,
-				&yaml.Node{Kind: yaml.ScalarNode, Value: ".@"},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: cData},
 				&yaml.Node{Kind: yaml.ScalarNode, Value: charEle.Data})
 		}
 		return nodeKey, nodeVal, nil
@@ -193,7 +194,7 @@ func XML2YAMLRecursive(ele *etree.Element) (key *yaml.Node, value *yaml.Node, er
 		children = &yaml.Node{Kind: yaml.MappingNode}
 		children.Content = []*yaml.Node{}
 		nodeVal.Content = append(nodeVal.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: ".@"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: cData},
 			children)
 	} else {
 		children = nodeVal
@@ -251,7 +252,7 @@ func XML2YAMLRecursive(ele *etree.Element) (key *yaml.Node, value *yaml.Node, er
 	}
 
 	childrenIndex := slices.IndexFunc(nodeVal.Content, func(e *yaml.Node) bool {
-		return e.Value == ".@"
+		return e.Value == cData
 	})
 
 	if childrenIndex > 0 && children != nodeVal &&

--- a/pkg/utils/yaml.go
+++ b/pkg/utils/yaml.go
@@ -135,7 +135,7 @@ func YAML2XMLRecursive(node *yaml.Node, parent *etree.Element) (*etree.Element, 
 	} else if node.Kind == yaml.MappingNode {
 		if parent != nil {
 			for i := 0; i+1 < len(node.Content); i += 2 {
-				if len(node.Content[i].Value) > 1 && node.Content[i].Value[0] == '.' && node.Content[i].Value[1] != '@' &&
+				if len(node.Content[i].Value) > 1 && node.Content[i].Value[0] == '.' &&
 					node.Content[i+1].Kind == yaml.ScalarNode {
 					parent.CreateAttr(node.Content[i].Value[1:], node.Content[i+1].Value)
 				}
@@ -143,9 +143,9 @@ func YAML2XMLRecursive(node *yaml.Node, parent *etree.Element) (*etree.Element, 
 		}
 
 		for i := 0; i+1 < len(node.Content); i += 2 {
-			if len(node.Content[i].Value) > 1 && node.Content[i].Value[0] == '.' && node.Content[i].Value[1] != '@' {
+			if len(node.Content[i].Value) > 1 && node.Content[i].Value[0] == '.' {
 				continue
-			} else if strings.Index(node.Content[i].Value, ".@") == 0 {
+			} else if strings.Index(node.Content[i].Value, "-") == 0 {
 				_, _ = YAML2XMLRecursive(node.Content[i+1], parent)
 			} else {
 				child := parent.CreateElement(node.Content[i].Value)


### PR DESCRIPTION
Received some feedback (from Kurt) that the .@ convention is somewhat jarring, and not easy to grasp right away. 
So, to reduce the friction, I am changing the container to be defined by a field that starts with a data.

It could be anything you want, -Data, or -Value-Content, etc.

Now, for the actual xml2yaml tool, I chose -Data as the name "Data" could imply either pure char-data, or actual children elements, so it works on both scenarios.